### PR TITLE
Adds verbose package name

### DIFF
--- a/lib/dco/cli.rb
+++ b/lib/dco/cli.rb
@@ -22,6 +22,8 @@ require 'thor'
 
 module Dco
   class CLI < Thor
+    package_name 'Developer Certificate of Origin (dco)'
+
     # Because this isn't the default and exit statuses are what the cool kids do.
     def self.exit_on_failure?
       true


### PR DESCRIPTION
When you run the command `dco` you will get the outout:
```
$ dco
Commands:
  dco check           # Check if a branch or repository has valid sign-off
  dco disable         # Disable auto-sign-off for this repository
  dco enable          # Enable auto-sign-off for this repository
  dco help [COMMAND]  # Describe available commands or one specific command
  dco sign            # Retroactively apply sign-off to the a branch
```

It could be a little bit difficult to know what this command does
without a proper description and, since Thor doesn't allow you to
describe the top level command I would propose to at least use the
`package_name` to display a more verbose usage like the following:
```
$ dco
Developer Certificate of Origin (dco) commands:
  dco check           # Check if a branch or repository has valid sign-off
  dco disable         # Disable auto-sign-off for this repository
  dco enable          # Enable auto-sign-off for this repository
  dco help [COMMAND]  # Describe available commands or one specific command
  dco sign            # Retroactively apply sign-off to the a branch
```

Signed-off-by: Salim Afiune <afiune@chef.io>